### PR TITLE
[codex] Split 1080 ligero presets

### DIFF
--- a/UniversalVideoCompressor_NVENC.py
+++ b/UniversalVideoCompressor_NVENC.py
@@ -826,7 +826,8 @@ def main():
             ("Upscale a ~4K (Pesado)", {"cq": "21", "bitrate": "14M", "maxrate": "17.5M", "bufsize": "24M", "scale": "3840:-2", "suffix": "_Upscale_Pesado_4K.mkv"}),
             ("Upscale a ~4K (Ligero)", {"cq": "24", "bitrate": "10M", "maxrate": "12M", "bufsize": "16M", "scale": "3840:-2", "suffix": "_Upscale_Ligero_4K.mkv"}),
             ("Mantener ~1080p (Pesado)", {"cq": "17", "bitrate": "14M", "maxrate": "17.5M", "bufsize": "24M", "scale": None, "suffix": "_Mantener_1080p_Pesado.mkv"}),
-            ("Mantener ~1080p (Ligero)", {"cq": "28", "bitrate": "3.2M", "maxrate": "4.2M", "bufsize": "6M", "preset": "p7", "scale": None, "suffix": "_Mantener_1080p_Ligero.mkv"}),
+            ("Mantener ~1080p (Ligero)", {"cq": "25", "bitrate": "4.8M", "maxrate": "6.2M", "bufsize": "9M", "preset": "p7", "scale": None, "suffix": "_Mantener_1080p_Ligero.mkv"}),
+            ("Mantener ~1080p (Ultra Ligero)", {"cq": "28", "bitrate": "3.2M", "maxrate": "4.2M", "bufsize": "6M", "preset": "p7", "scale": None, "suffix": "_Mantener_1080p_UltraLigero.mkv"}),
             ("Downscale a 720p", {"cq": "24", "bitrate": "4M", "maxrate": "5M", "bufsize": "6M", "scale": "1280:-2", "suffix": "_720p.mkv"}),
         ]
     elif is_hd_ish: # Si es 720p o cercano


### PR DESCRIPTION
## What changed

This updates the 1080p lightweight preset split so the default `Ligero` mode is less destructive, and preserves the older more aggressive settings as a separate `Ultra Ligero` option.

## Why

A real-world 1080p WEBRip test showed that the previous lightweight profile could drive video bitrate too low for some sources, causing visible loss of hair detail, dark-shape definition, and fine texture.

## Impact

Users now get two distinct 1080p lightweight choices:

- `Mantener ~1080p (Ligero)` tuned to be safer for image quality
- `Mantener ~1080p (Ultra Ligero)` for cases where size matters more than fidelity

## Root cause

The single lightweight preset was trying to serve two conflicting goals at once:

1. strong size reduction
2. acceptable detail retention on harder 1080p sources

Those goals do not fit one aggressively compressed profile reliably, so the preset has been split.

## Validation

- `python -m py_compile UniversalVideoCompressor_NVENC.py`
- 3-minute side-by-side encode tests on `Ready.or.Not.2.Here.I.Come.2026.1080p.Webrip.Multi.Line.Audio.x264-SyncUP.mkv`
- Verified that the current `Ligero` profile remains substantially larger and visually safer than `Ultra Ligero`
